### PR TITLE
adding clusterlifecycle tables

### DIFF
--- a/pgo/postgres-job.yaml
+++ b/pgo/postgres-job.yaml
@@ -26,7 +26,7 @@ spec:
               secretKeyRef:
                 name: hoh-pguser-postgres
                 key: password
-        image: quay.io/ianzhang366/postgre-ansible:latest
+        image: ${IMG}
         command: ["/bin/bash", "-c", "ansible-playbook pgo.yaml -i production -l local"]
       restartPolicy: Never
   backoffLimit: 3

--- a/pgo/setup.sh
+++ b/pgo/setup.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+img="quay.io/ianzhang366/postgre-ansible:latest"
+
+cd ../
+docker build -f Dockerfile -t $img .
+docker push $img
+
+cd pgo
+
 # install the pgo operator to postgres-operator
 kubectl apply -k ./install
 
@@ -17,7 +25,9 @@ while [ -z "$matched" ]; do
     sleep 10
 done
 
-kubectl apply -f ./postgres-job.yaml
+kubectl delete -f ./postgres-job.yaml
+
+IMG=$img envsubst < ./postgres-job.yaml | kubectl apply -f -
 
 kubectl wait --for=condition=complete job/postgres-init -n $pg_namespace --timeout=120s
 

--- a/roles/create_tables/tasks/create_spec_tables.yaml
+++ b/roles/create_tables/tasks/create_spec_tables.yaml
@@ -12,5 +12,9 @@
     - subscriptions
     - channels
     - applications
+    - clusterdeployments
+    - secrets
+    - machinepools
+    - klusterletaddonconfigs
   loop_control:
     loop_var: name

--- a/roles/create_tables/tasks/create_status_clusterlifecycle_table.yaml
+++ b/roles/create_tables/tasks/create_status_clusterlifecycle_table.yaml
@@ -1,0 +1,43 @@
+---
+- name: create table {{ name }} schema {{ schema }} database {{ database }}
+  tags: tables
+  postgresql_table:
+    name: "{{ status_schema }}.{{ name }}"
+    db: "{{ database }}"
+    login_host: "{{ db_login_host }}"
+    login_user: "{{ db_login_user }}"
+    login_password: "{{ db_login_password }}"
+    ssl_mode: "{{ db_ssl_mode }}"
+    columns:
+      - id uuid not null
+      - leaf_hub_name varchar({{ cluster_name_length_limit }}) not null
+      - payload jsonb not null
+
+
+- name: create index on payload->'metadata'->>'name' for table {{ name }}
+  postgresql_idx:
+    name: "{{ name }}_metadata_name_idx"
+    table: "{{ name }}"
+    schema: "{{ status_schema }}"
+    db: "{{ database }}"
+    login_host: "{{ db_login_host }}"
+    login_user: "{{ db_login_user }}"
+    login_password: "{{ db_login_password }}"
+    ssl_mode: "{{ db_ssl_mode }}"
+    columns: "(payload->'metadata'->>'name')"
+    idxtype: btree
+    unique: true
+
+- name: create index on payload->'metadata'->>'namespace'  for table {{ name }}
+  postgresql_idx:
+    name: "{{ name }}_metadata_namespace_idx"
+    table: "{{ name }}"
+    schema: "{{ status_schema }}"
+    db: "{{ database }}"
+    login_host: "{{ db_login_host }}"
+    login_user: "{{ db_login_user }}"
+    login_password: "{{ db_login_password }}"
+    ssl_mode: "{{ db_ssl_mode }}"
+    columns: "(payload->'metadata'->>'namespace')"
+    idxtype: btree
+    unique: true

--- a/roles/create_tables/tasks/create_status_tables.yaml
+++ b/roles/create_tables/tasks/create_status_tables.yaml
@@ -138,3 +138,15 @@
       - leaf_hub_name varchar({{ cluster_name_length_limit }}) not null
       - payload jsonb not null
 
+- name: create cluster lifecycle status tables
+  tags: tables
+  vars:
+    database: "{{ hoh_db }}"
+  include_tasks: create_status_clusterlifecycle_table.yaml
+  loop:
+    - clusterdeployments
+    - secrets
+    - machinepools
+    - klusterletaddonconfigs
+  loop_control:
+    loop_var: name


### PR DESCRIPTION
This PR is adding cluster lifecycle-related tables to DB.

Also, it makes sure when applying the `./pgo/setup.sh`, the docker image is updated

Signed-off-by: Ian Zhang <izhang@redhat.com>