### PR TITLE
Setup script fix

### DIFF
--- a/pgo/README.md
+++ b/pgo/README.md
@@ -9,9 +9,9 @@ If we can run the hoh postgres DB inside cluster as an operator to test/try our 
 
 # How to do
 1. make sure your `KUBECONFIG` is pointing the HoH cluster. Ask your cluster's admin to give you appropriate permissions.
-2. set the `USERNAME` environment variable to hold the username part of your docker registry:
+2. set the `USER_NAME` environment variable to hold the username part of your docker registry:
     ```
-    $ export USERNAME=...
+    $ export USER_NAME=...
     ```
 3. run `./setup.sh`
 

--- a/pgo/setup.sh
+++ b/pgo/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# use USERNAME=ianzhang366 in case you do not have your docker image
-img="quay.io/$USERNAME/postgre-ansible:latest"
+# use USER_NAME=ianzhang366 in case you do not have your docker image
+img="quay.io/$USER_NAME/postgre-ansible:latest"
 
 cd ../
 docker build -f Dockerfile -t $img .


### PR DESCRIPTION
The setup.sh script uses the USERNAME environment variable, this environment variable can't be used in some shells so I changed it to USER_NAME.